### PR TITLE
fix: macOS/Linux 启动问题修复

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "novix-frontend",
       "version": "0.1.0",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "axios": "^1.6.2",
         "clsx": "^2.1.1",


### PR DESCRIPTION
### 问题
在 macOS 上按 README 执行 `./start.sh` 无法正常启动，存在以下问题：

1. shell 脚本缺少执行权限
2. `requirements.txt` 缺少 `slowapi` 和 `aiohttp` 依赖
3. 开发模式下静态文件目录检查逻辑有误

### 修复内容
- 为 `start.sh`、`backend/run.sh`、`frontend/run.sh` 添加执行权限
- 补充缺失的 Python 依赖
- 修复 `main.py` 中静态文件目录的判断逻辑

### 测试
macOS 14 + Python 3.14 + Node 18，前后端均可正常启动。
