### PR TITLE
feat: 新增Mock Provider测试模式

### DIFF
--- a/backend/app/llm_gateway/gateway.py
+++ b/backend/app/llm_gateway/gateway.py
@@ -5,7 +5,6 @@ Unified interface with retry, rate limiting, and cost tracking
 """
 
 import asyncio
-import os
 import time
 from typing import List, Dict, Any, Optional
 import app.config as app_config
@@ -16,6 +15,7 @@ from app.llm_gateway.providers import (
     OpenAIProvider,
     AnthropicProvider,
     DeepSeekProvider,
+    MockProvider,
     CustomProvider,
     QwenProvider,
     KimiProvider,
@@ -47,7 +47,7 @@ class LLMGateway:
         # Cost tracking / 成本追踪
         self.total_tokens = 0
         self.total_requests = 0
-    
+
     def _init_profiles(self) -> None:
         """Initialize LLM providers from stored profiles"""
         self.providers = {}
@@ -139,6 +139,8 @@ class LLMGateway:
                     max_tokens=profile.get("max_tokens", 8000),
                     temperature=profile.get("temperature", 0.7)
                 )
+            elif provider_type == "mock":
+                return MockProvider()
         except Exception as e:
             logger.error(f"Error creating provider instance for {profile.get('name')}: {e}")
             return None

--- a/backend/app/llm_gateway/providers/mock_provider.py
+++ b/backend/app/llm_gateway/providers/mock_provider.py
@@ -1,4 +1,6 @@
-from typing import List, Dict, Any, Optional
+import json
+from typing import Any, Dict, List, Optional
+
 from app.llm_gateway.providers.base import BaseLLMProvider
 
 
@@ -12,14 +14,7 @@ class MockProvider(BaseLLMProvider):
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
     ) -> Dict[str, Any]:
-        prompt = "\n".join([f"{m.get('role')}: {m.get('content')}" for m in messages])
-        content = (
-            "[MOCK] NOVIX is running in demo mode.\n\n"
-            "No API key is configured, so this is a placeholder response.\n\n"
-            "---\n"
-            "Input:\n"
-            f"{prompt}\n"
-        )
+        content = self._build_mock_content(messages=messages)
 
         return {
             "content": content,
@@ -31,6 +26,107 @@ class MockProvider(BaseLLMProvider):
             "model": self.model,
             "finish_reason": "stop",
         }
+
+    async def stream_chat(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+    ):
+        content = self._build_mock_content(messages=messages)
+        chunk_size = 80
+        for i in range(0, len(content), chunk_size):
+            yield content[i : i + chunk_size]
+
+    def _has_all(self, text: str, keywords: List[str]) -> bool:
+        return all(k in text for k in keywords)
+
+    def _build_mock_content(self, messages: List[Dict[str, str]]) -> str:
+        message_text = "\n".join([str(m.get("content") or "") for m in (messages or [])])
+        lower_text = message_text.lower()
+
+        # JSON list: writer pre-writing questions
+        if self._has_all(message_text, ["json", "type", "plot_point", "text"]):
+            return json.dumps(
+                [
+                    {"type": "plot_point", "text": "本章必须完成的关键事件是什么？请给出一个可落地场景。"},
+                    {"type": "character_change", "text": "主角此章情绪或动机要发生什么变化？"},
+                    {"type": "detail_gap", "text": "地点、时间或关键道具还有哪些细节需要先确认？"},
+                ],
+                ensure_ascii=False,
+            )
+
+        # YAML: chapter summary
+        if self._has_all(lower_text, ["yaml", "new_facts", "brief_summary", "key_events"]):
+            return (
+                "chapter: V1C1\n"
+                "title: Mock章节\n"
+                "word_count: 1200\n"
+                "key_events:\n"
+                "  - 主角在旧城区获得关键线索\n"
+                "  - 主角与同伴发生立场分歧\n"
+                "new_facts:\n"
+                "  - 旧城区地下网络由灰潮会控制\n"
+                "  - 主角掌握了进入档案库的临时口令\n"
+                "character_state_changes:\n"
+                "  - 主角对同伴的信任下降\n"
+                "open_loops:\n"
+                "  - 口令有效期尚未确认\n"
+                "brief_summary: 主角在追查中取得突破，但团队关系出现裂痕。\n"
+            )
+
+        # YAML: canon updates
+        if self._has_all(lower_text, ["yaml", "facts:", "timeline_events", "character_states"]):
+            return (
+                "facts:\n"
+                "  - statement: 旧城区地下网络由灰潮会控制\n"
+                "    confidence: 0.9\n"
+                "  - statement: 主角获得进入档案库的临时口令\n"
+                "    confidence: 0.85\n"
+                "timeline_events:\n"
+                "  - time: 当夜\n"
+                "    event: 主角潜入旧城区取得情报\n"
+                "    participants: [主角, 同伴]\n"
+                "    location: 旧城区\n"
+                "character_states:\n"
+                "  - character: 主角\n"
+                "    goals: [进入档案库]\n"
+                "    injuries: []\n"
+                "    inventory: [临时口令]\n"
+                "    relationships: {同伴: 信任下降}\n"
+                "    location: 旧城区\n"
+                "    emotional_state: 警惕\n"
+            )
+
+        # YAML: volume summary
+        if self._has_all(lower_text, ["yaml", "volume_id", "chapter_count", "major_events"]):
+            return (
+                "volume_id: V1\n"
+                "brief_summary: 主线围绕调查旧城区势力展开，冲突持续升级。\n"
+                "key_themes:\n"
+                "  - 信任与背叛\n"
+                "major_events:\n"
+                "  - 主角获取关键情报\n"
+                "chapter_count: 3\n"
+            )
+
+        # JSON object: fanfiction card extraction
+        if self._has_all(lower_text, ["json", "name", "type", "description"]) and (
+            "character" in lower_text or "world" in lower_text
+        ):
+            return json.dumps(
+                {
+                    "name": "Mock角色",
+                    "type": "Character",
+                    "description": "该角色身份明确，行动目标稳定。外在特征鲜明，言行克制。与主角存在持续博弈关系，是推动主线冲突的关键人物。",
+                },
+                ensure_ascii=False,
+            )
+
+        # Draft fallback
+        return (
+            "Mock内容生成：根据输入的提示词，返回了这段文本。你可以根据需要修改 MockProvider 的 _build_mock_content 方法来定制不同的返回内容，以便测试不同的场景和功能。"
+        )
 
     def get_provider_name(self) -> str:
         return "mock"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,12 @@
 # Core Web Framework
 fastapi>=0.109.0
+slowapi>=0.1.9
 uvicorn[standard]>=0.27.0
 python-multipart>=0.0.6
 pydantic>=2.5.0
 pydantic-settings>=2.1.0
+numpy>=2.4.2
+aiohttp>=3.13.3
 
 # CORS and WebSockets
 python-dotenv>=1.0.0

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -5,18 +5,38 @@
 echo "Starting NOVIX Backend Server..."
 echo "正在启动 NOVIX 后端服务器..."
 
+# Optional mode flag: test / --test
+TEST_MODE=0
+for arg in "$@"; do
+    if [ "$arg" = "test" ] || [ "$arg" = "--test" ]; then
+        TEST_MODE=1
+        echo "Test mode enabled: passing 'test' arg to app.main"
+    fi
+done
+
+# Detect python3 or python, set PYTHON variable
+if command -v python3 &> /dev/null; then
+    PYTHON=python3
+elif command -v python &> /dev/null; then
+    PYTHON=python
+else
+    echo "[错误] 未检测到 Python，请先安装 Python 3.10+"
+    exit 1
+fi
+echo "Using Python interpreter: $($PYTHON --version 2>&1)"
+
 # Check if virtual environment exists / 检查虚拟环境是否存在
 if [ ! -d "venv" ]; then
     echo "Virtual environment not found. Creating..."
     echo "虚拟环境不存在，正在创建..."
-    python -m venv venv
+    $PYTHON -m venv venv
 fi
 
 source venv/bin/activate
 
 echo "Installing dependencies..."
 echo "正在安装依赖..."
-python -m pip install -r requirements.txt
+$PYTHON -m pip install -r requirements.txt
 
 # Check if .env exists / 检查 .env 是否存在
 if [ ! -f ".env" ]; then
@@ -36,4 +56,4 @@ echo "服务器启动于 http://localhost:8000"
 echo "API Docs: http://localhost:8000/docs"
 echo ""
 
-python -m app.main
+$PYTHON -m app.main "$@"

--- a/start.sh
+++ b/start.sh
@@ -23,11 +23,18 @@ fi
 
 # 获取脚本所在目录
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BACKEND_MODE_ARG=""
+for arg in "$@"; do
+    if [ "$arg" = "test" ] || [ "$arg" = "--test" ]; then
+        BACKEND_MODE_ARG="test"
+        break
+    fi
+done
 
 echo "[1/3] 启动后端服务..."
-osascript -e "tell app \"Terminal\" to do script \"cd '$SCRIPT_DIR/backend' && ./run.sh\"" 2>/dev/null || \
-gnome-terminal -- bash -c "cd '$SCRIPT_DIR/backend' && ./run.sh; exec bash" 2>/dev/null || \
-xterm -e "cd '$SCRIPT_DIR/backend' && ./run.sh" 2>/dev/null &
+osascript -e "tell app \"Terminal\" to do script \"cd '$SCRIPT_DIR/backend' && ./run.sh $BACKEND_MODE_ARG\"" 2>/dev/null || \
+gnome-terminal -- bash -c "cd '$SCRIPT_DIR/backend' && ./run.sh $BACKEND_MODE_ARG; exec bash" 2>/dev/null || \
+xterm -e "cd '$SCRIPT_DIR/backend' && ./run.sh $BACKEND_MODE_ARG" 2>/dev/null &
 
 sleep 3
 


### PR DESCRIPTION
 ### 解决的问题或实现的功能

- 增加 mock LLM provider，支持在无真实 API 调用成本下跑通写作/分析流程。
- 启动脚本支持 test/--test 参数。
- 统一 Python 解释器检测，完善依赖安装流程。

### 技术方案简述

- mock_provider.py: 实现基于 prompt 关键词组合的 mock 返回逻辑。
- llm_config_service.py: 启动时可根据命令参数（test/--test）创建 mock profile。