### PR TITLE
fix:修复写作确认功能/Fix the writing confirmation feature

### DIFF
--- a/backend/app/agents/writer.py
+++ b/backend/app/agents/writer.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """
 文枢 WenShape - 深度上下文感知的智能体小说创作系统
 WenShape - Deep Context-Aware Agent-Based Novel Writing System
@@ -131,7 +131,7 @@ class WriterAgent(BaseAgent):
             evidence_pack=evidence_pack,
         )
 
-        pending_confirmations = self._extract_confirmations(draft_content)
+        pending_confirmations = []
         word_count = len(draft_content)
 
         draft = await self.draft_storage.save_draft(
@@ -227,7 +227,7 @@ class WriterAgent(BaseAgent):
         if err:
             logger.warning("Writer questions parse failed: %s", err)
             logger.debug("Writer questions raw preview: %s", str(raw or "")[:200])
-        if isinstance(data, list) and len(data) == 3:
+        if isinstance(data, list) and 1 <= len(data) <= 5:
             cleaned = []
             for item in data:
                 if not isinstance(item, dict):
@@ -236,7 +236,7 @@ class WriterAgent(BaseAgent):
                 text = item.get("text")
                 if q_type and text:
                     cleaned.append({"type": q_type, "text": text})
-            if len(cleaned) == 3:
+            if cleaned:
                 return cleaned
 
         return list(self.DEFAULT_QUESTIONS)
@@ -656,26 +656,4 @@ FORBIDDEN:
         if not items:
             return "None"
         return "\n".join([f"- {item}" for item in items])
-
-    def _extract_confirmations(self, content: str) -> List[str]:
-        """
-        从生成内容中提取待确认项 - 查找 [TO_CONFIRM:...] 标记
-
-        Extract [TO_CONFIRM:...] markers from draft content for user review.
-        These mark uncertain facts that require user confirmation.
-
-        Args:
-            content: Generated draft text.
-
-        Returns:
-            List of confirmation texts (content between [TO_CONFIRM: and ]).
-        """
-        confirmations = []
-        for line in content.split("\n"):
-            if "[TO_CONFIRM:" in line:
-                start = line.find("[TO_CONFIRM:") + 12
-                end = line.find("]", start)
-                if end > start:
-                    confirmations.append(line[start:end].strip())
-        return confirmations
 

--- a/backend/app/orchestrator/_context_mixin.py
+++ b/backend/app/orchestrator/_context_mixin.py
@@ -262,9 +262,6 @@ class ContextMixin:
             except Exception as exc:
                 logger.warning("Working memory build failed: %s", exc)
 
-        if working_memory_payload and not working_memory_payload.get("research_stop_reason"):
-            working_memory_payload["questions"] = []
-
         return working_memory_payload
 
     async def _load_memory_pack(self, project_id: str, chapter: str) -> Optional[Dict[str, Any]]:

--- a/backend/app/prompts.py
+++ b/backend/app/prompts.py
@@ -382,18 +382,6 @@ WRITER_SYSTEM_PROMPT = _u_shape(
             "  - 通过动作、环境、对话承载情绪（而非直白解释）",
             "  - 避免同一句意思的重复表达",
             "",
-            "### [TO_CONFIRM] 标记使用规范",
-            "",
-            "适用场景（仅标记关键不确定点）：",
-            "  - 影响剧情一致性的细节",
-            "  - 涉及角色动机的关键信息",
-            "  - 关系到世界规则的设定",
-            "",
-            "使用格式：",
-            "  [TO_CONFIRM:需要确认的具体内容]",
-            "",
-            "技巧：可以写「含混但不矛盾」的表达，只写感受不写原因，再标记缺口",
-            "",
             "### 输出禁忌（常见扣分项）",
             "",
             f"{P0_MARKER} 禁止在正文中出现系统词汇：",
@@ -407,7 +395,6 @@ WRITER_SYSTEM_PROMPT = _u_shape(
             "□ 是否违反任何禁忌/规则？",
             "□ 角色身份/关系/时间线/地点是否与证据一致？",
             "□ 是否存在「看似合理但无证据支撑」的硬细节？",
-            "□ [TO_CONFIRM] 是否覆盖了所有关键不确定点？",
         ]
     ),
 )
@@ -440,7 +427,7 @@ def writer_questions_prompt(context_items: List[str]) -> PromptPair:
             "",
             f"{P0_MARKER} 信息已在证据包中明确给出时，不再重复询问",
             "",
-            _json_only_rules("输出 JSON 数组，恰好 3 项，每项包含 type 和 text 字段"),
+            _json_only_rules("输出 JSON 数组，1-3 项，每项包含 type 和 text 字段"),
         ]
     )
     system = _u_shape(
@@ -471,7 +458,7 @@ def writer_questions_prompt(context_items: List[str]) -> PromptPair:
         [
             "### 输出格式规范",
             "",
-            "输出 JSON 数组，恰好 3 项。每项结构：",
+            "输出 JSON 数组，1-3 项。每项结构：",
             "```json",
             '{"type": "问题类型", "text": "问题文本"}',
             "```",

--- a/frontend/src/utils/writingSessionHelpers.js
+++ b/frontend/src/utils/writingSessionHelpers.js
@@ -31,22 +31,6 @@ export const fetchChapterContent = async ([_, projectId, chapter]) => {
 /** 计算文本字符数（忽略空格） */
 export const countChars = (text) => (text || '').replace(/\s/g, '').length;
 
-/** 提取文本中的 [TO_CONFIRM:xxx] 标记 */
-export const extractToConfirmKeys = (text) => {
-  const keys = [];
-  const content = String(text || '');
-  const regex = /\[TO_CONFIRM:([^\]]+)\]/g;
-  let match = null;
-  while ((match = regex.exec(content)) !== null) {
-    const key = match[1].trim();
-    if (key && !keys.includes(key)) {
-      keys.push(key);
-    }
-    if (keys.length >= 12) break;
-  }
-  return keys;
-};
-
 /** 转义正则表达式特殊字符 */
 export const escapeRegExp = (value) => String(value || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 


### PR DESCRIPTION
Fix 1：移除 writer.py BOM
- 使用 Python 脚本移除文件头的 UTF-8 BOM 字节

Fix 2：修复写前确认触发逻辑
- 门控 1 (_context_mixin.py:265-266)：删除了在 fallback 路径下强制清空 questions 的逻辑
- 门控 3 (orchestrator.py:203-204)：改 `if questions is None:` → `if not questions:`，使空列表也能触发 LLM 生成

Fix 3：放宽问题数量限制
- writer.py 第 230-240 行：从严格要求"恰好3个"改为"1-5个"
- prompts.py 第 443、474 行：同步更新提示词中的说明

Fix 4：移除后端 TO_CONFIRM 机制
- prompts.py：删除了 `### [TO_CONFIRM] 标记使用规范` 段落和自检清单中相关项
- writer.py：删除了 `_extract_confirmations()` 方法
- orchestrator.py：删除了 `_collect_pending_confirmations()` 方法，改为直接返回空列表

Fix 5：移除前端 TO_CONFIRM 机制
- WritingSession.jsx：
  - 删除 `showToConfirmDialog` 和 `toConfirmQuestions` 两个 state
  - 删除 `applyToConfirmAnswers()` 函数
  - 删除第二个 `PreWritingQuestionsDialog` 渲染
  - 删除 `handleDraftV1` 和 `handleFinalDraft` 中 3 处 `extractToConfirmKeys` 的调用和相关弹窗逻辑
- writingSessionHelpers.js：删除了 `extractToConfirmKeys` 函数

Fix 1: Remove BOM from writer.py
- Use a Python script to remove the UTF-8 BOM bytes at the start of the file

Fix 2: Fix the pre-writing confirmation trigger logic
- Gate 1 (_context_mixin.py:265-266): Removed the logic that forcibly clears `questions` in the fallback path
- Gate 3 (orchestrator.py:203-204): Changed `if questions is None:` to `if not questions:`, so empty lists can also trigger LLM generation

Fix 3: Relax the limit on the number of questions
- writer.py lines 230-240: Changed from strictly requiring "exactly 3" to "1-5"
- prompts.py lines 443, 474: Synchronously updated the descriptions in the prompt words

Fix 4: Remove the backend TO_CONFIRM mechanism
- prompts.py: Deleted the section of "### [TO_CONFIRM] Mark Usage Specification" and related items in the self-checklist
- writer.py: Deleted the `_extract_confirmations()` method
- orchestrator.py: Deleted the `_collect_pending_confirmations()` method and replaced it with directly returning an empty list

Fix 5: Remove the frontend TO_CONFIRM mechanism
- WritingSession.jsx:
  - Deleted two states: `showToConfirmDialog` and `toConfirmQuestions`
  - Deleted the `applyToConfirmAnswers()` function
  - Deleted the rendering of the second `PreWritingQuestionsDialog`
  - Deleted 3 calls to `extractToConfirmKeys` and related pop-up logic in `handleDraftV1` and `handleFinalDraft`
- writingSessionHelpers.js: Deleted the `extractToConfirmKeys` function