### PR TITLE
fix：项目切换时完整清理

### DIFF
--- a/frontend/src/pages/WritingSession.jsx
+++ b/frontend/src/pages/WritingSession.jsx
@@ -67,12 +67,44 @@ function WritingSessionContent({ isEmbedded = false }) {
     // ========================================================================
     // 项目数据状态 / Project data from API
     const [project, setProject] = useState(null);
+    const prevProjectIdRef = useRef(null);
+
     useEffect(() => {
         if (projectId) {
             projectsAPI.get(projectId).then(res => setProject(res.data));
             dispatch({ type: 'SET_PROJECT_ID', payload: projectId });
         }
     }, [projectId, dispatch]);
+
+    // 项目切换时清理所有会话状态，防止数据污染
+    // 使用 useRef 判断 projectId 是否真正变化，避免不必要的清理
+    useEffect(() => {
+        if (prevProjectIdRef.current && prevProjectIdRef.current !== projectId) {
+            // 项目真正切换了：清理所有写作会话状态
+            setDiffReview(null);
+            setDiffDecisions({});
+            setCurrentDraft(null);
+            setManualContent('');
+            setManualContentByChapter({});
+            setMessagesByChapter({});
+            setProgressEventsByChapter({});
+            setDraftV1(null);
+            setSceneBrief(null);
+            setFeedback('');
+            setChapterInfo({ chapter: null, chapter_title: null, content: null });
+            setStatus('idle');
+            setSelectionInfo({ start: 0, end: 0, text: '' });
+            setAttachedSelection(null);
+            setEditScope('document');
+            setAiLockedChapter(null);
+            if (streamingRef.current?.timer) {
+                streamingRef.current.timer();
+            }
+            streamingRef.current = null;
+            setStreamingState({ active: false, progress: 0, current: 0, total: 0 });
+        }
+        prevProjectIdRef.current = projectId;
+    }, [projectId]);
 
 
 


### PR DESCRIPTION
---

## 描述

**问题**：在 WritingSession 中切换项目时，上一个项目的数据（diff、草稿、消息等）仍保留在状态中，导致 UI 显示混乱或潜在错误。

**解决方案**：新增一个 `useEffect`，监听 `projectId` 变化，并在项目真正切换时执行完整的状态重置。

**关键设计**：
- 使用 `useRef` (`prevProjectIdRef`) 记录前一个 `projectId`，避免初始化时误触发重置。
- 重置条件：`prevProjectIdRef.current && prevProjectIdRef.current !== projectId`
- 完整清理列表包括：
  - diff 相关：`diffReview`、`diffDecisions`
  - 草稿相关：`currentDraft`、`draftV1`、`sceneBrief`、`feedback`
  - 编辑器内容：`manualContent`、`manualContentByChapter`
  - 缓存数据：`messagesByChapter`、`progressEventsByChapter`
  - 章节选择：`chapterInfo`、`selectionInfo`、`attachedSelection`
  - UI 状态：`status`、`editScope`、`aiLockedChapter`、`streamingState`
  - 中断流式生成：清除 `streamingRef` 的定时器
- 重置后更新 `prevProjectIdRef.current`，供下次比较使用。

**修改文件**：
- `frontend/src/pages/WritingSession.jsx`（第 79–107 行）

**影响**：确保切换项目时状态完全重置，避免数据残留和界面异常。

## Description

**Problem**: When switching projects in the WritingSession, previous project's data (diffs, drafts, messages, etc.) remained in the state, causing UI inconsistencies and potential errors.

**Solution**: Added a `useEffect` that listens to `projectId` changes and performs a full state reset when the project actually changes.

**Key Implementation Details**:
- Used `useRef` (`prevProjectIdRef`) to track the previous `projectId` and avoid reset on initial mount.
- Reset condition: `prevProjectIdRef.current && prevProjectIdRef.current !== projectId`
- Comprehensive cleanup includes:
  - Diff-related: `diffReview`, `diffDecisions`
  - Draft-related: `currentDraft`, `draftV1`, `sceneBrief`, `feedback`
  - Editor content: `manualContent`, `manualContentByChapter`
  - Cached data: `messagesByChapter`, `progressEventsByChapter`
  - Chapter selection: `chapterInfo`, `selectionInfo`, `attachedSelection`
  - UI states: `status`, `editScope`, `aiLockedChapter`, `streamingState`
  - Streaming interruption: clear timer in `streamingRef`
- Updates `prevProjectIdRef.current` after reset for next comparison.

**Files Changed**:
- `frontend/src/pages/WritingSession.jsx` (lines 79–107)

**Impact**: Ensures clean state when switching projects, preventing cross-project data leakage and UI glitches.
