### PR TITLE
fix:手动编辑保存后刷新回退问题

### DIFF
--- a/backend/app/routers/drafts.py
+++ b/backend/app/routers/drafts.py
@@ -52,15 +52,6 @@ async def list_draft_versions(project_id: str, chapter: str) -> List[str]:
     return await draft_storage.list_draft_versions(project_id, chapter)
 
 
-@router.get("/{chapter}/{version}")
-async def get_draft(project_id: str, chapter: str, version: str):
-    """Get a specific draft version / 获取指定草稿版本"""
-    draft = await draft_storage.get_draft(project_id, chapter, version)
-    if not draft:
-        raise HTTPException(status_code=404, detail="Draft not found")
-    return draft
-
-
 @router.get("/{chapter}/review")
 async def get_review(project_id: str, chapter: str):
     """Get review result / 获取审稿结果"""
@@ -226,3 +217,15 @@ async def autosave_draft_content(project_id: str, chapter: str, body: UpdateCont
         "chapter": canonical,
         "title": body.title,
     }
+
+
+# 注意：/{chapter}/{version} 通配路由必须在所有具体路由之后注册
+# 否则会遮蔽 /{chapter}/final, /{chapter}/review 等具体路由
+# FastAPI 按注册顺序从上到下匹配，先匹配先赢
+@router.get("/{chapter}/{version}")
+async def get_draft(project_id: str, chapter: str, version: str):
+    """Get a specific draft version / 获取指定草稿版本"""
+    draft = await draft_storage.get_draft(project_id, chapter, version)
+    if not draft:
+        raise HTTPException(status_code=404, detail="Draft not found")
+    return draft


### PR DESCRIPTION

---

## 描述

**问题**：通配路由 `/{chapter}/{version}` 在具体路由（如 `/{chapter}/final`、`/{chapter}/review`）之前注册。由于 FastAPI 按顺序匹配路由（先注册先匹配），导致通配路由拦截了本应匹配具体路由的请求，使得具体路由无法访问。

**解决方案**：将通配路由的注册移至所有具体路由之后，确保具体路由优先匹配。

**修改内容**：
- 删除原位置的通配路由定义（路由文件中第 55–61 行）。
- 在文件末尾（第 222–231 行）重新添加相同的路由，置于所有具体路由（如 autosave 路由）之后。

**代码片段（已删除）**：
```python
@router.get("/{chapter}/{version}")
async def get_draft(project_id: str, chapter: str, version: str):
    draft = await draft_storage.get_draft(project_id, chapter, version)
    if not draft:
        raise HTTPException(status_code=404, detail="Draft not found")
    return draft
```

**代码片段（末尾添加）**：
```python
@router.get("/{chapter}/{version}")
async def get_draft(project_id: str, chapter: str, version: str):
    """Get a specific draft version / 获取指定草稿版本"""
    draft = await draft_storage.get_draft(project_id, chapter, version)
    if not draft:
        raise HTTPException(status_code=404, detail="Draft not found")
    return draft
```

**影响**：解决路由遮蔽问题，确保 `/{chapter}/final` 等具体路由能够正常访问。

## Description

**Problem**: A wildcard route `/{chapter}/{version}` was registered before more specific routes (e.g., `/{chapter}/final`, `/{chapter}/review`). Due to FastAPI's route matching order (first-come, first-served), the wildcard route captured all requests intended for those specific endpoints, making them inaccessible.

**Solution**: Move the wildcard route registration after all concrete routes to ensure specific routes are matched first.

**Changes**:
- Removed the original wildcard route definition (lines 55–61 in the routing file).
- Re-added the same route at the end of the file (lines 222–231), after all other specific routes (e.g., autosave routes).

**Code snippet (removed)**:
```python
@router.get("/{chapter}/{version}")
async def get_draft(project_id: str, chapter: str, version: str):
    draft = await draft_storage.get_draft(project_id, chapter, version)
    if not draft:
        raise HTTPException(status_code=404, detail="Draft not found")
    return draft
```

**Code snippet (added at the end)**:
```python
@router.get("/{chapter}/{version}")
async def get_draft(project_id: str, chapter: str, version: str):
    """Get a specific draft version / 获取指定草稿版本"""
    draft = await draft_storage.get_draft(project_id, chapter, version)
    if not draft:
        raise HTTPException(status_code=404, detail="Draft not found")
    return draft
```

**Impact**: Resolves route shadowing; endpoints like `/{chapter}/final` now work correctly.
